### PR TITLE
Update bypass-paywall.js

### DIFF
--- a/reuters/bypass-paywall.js
+++ b/reuters/bypass-paywall.js
@@ -1,0 +1,8 @@
+// ==UserScript==
+// @name        Reuters Archive Redirect
+// @author      Nivyan Lakhani
+// @match       https://*.reuters.com/*
+// @run-at      document-start
+// @grant       none
+// ==/UserScript==
+(()=>{if(/archive\.today|archive\.is/.test(location.hostname))return;const r=/Subscribe to Reuters to continue reading/i,d=()=>{if(r.test(document.body?.innerText))location.replace('https://archive.today/'+location.href)};d();new MutationObserver(d).observe(document.documentElement,{childList:1,subtree:1})})();


### PR DESCRIPTION
Made it such that when the script detects any instance of the text: "Subscribe to Reuters to continue reading.". It instead fetches the latest link from `archive.today` or `archive.is`